### PR TITLE
Hide Google Maps key

### DIFF
--- a/EcoMoveValencia/.env.example
+++ b/EcoMoveValencia/.env.example
@@ -1,0 +1,1 @@
+GOOGLE_MAPS_API_KEY=your_api_key_here

--- a/EcoMoveValencia/api.js
+++ b/EcoMoveValencia/api.js
@@ -44,12 +44,19 @@ let taxiStations = [];
 let stationUsage;
 let stationBusUsage;
 let stationRodaliaUsage;
-let apiKey = "AIzaSyCzX88lbn1Xa_pouaPX4k_4IjRuJsjB064";
+// Clave de Google Maps obtenida de la variable de entorno
+const apiKey = process.env.GOOGLE_MAPS_API_KEY || "";
 const router = express.Router();
 app.use(cors());
 app.use(express.json()); // Asegura que el body se maneje como JSON
 app.use(express.urlencoded({ extended: true }));
-app.use(express.static(path.join(__dirname, 'public'))); 
+app.use(express.static(path.join(__dirname, 'public')));
+
+// Endpoint para proporcionar la clave de Google Maps al cliente
+app.get('/api/google-maps-key', (req, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    res.json({ apiKey });
+});
 // Ruta de prueba
 app.get('/api/getBicis', (req, res) => {
 	res.setHeader("Content-Type", "application/json");

--- a/EcoMoveValencia/public/index.html
+++ b/EcoMoveValencia/public/index.html
@@ -775,7 +775,16 @@
   <!-- Incluir iconos de Lucide -->
   <script src="https://unpkg.com/lucide@latest"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-  <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCzX88lbn1Xa_pouaPX4k_4IjRuJsjB064&libraries=geometry,places"></script>
+  <script>
+    // Carga dinámica de Google Maps con la clave obtenida del servidor
+    fetch('/api/google-maps-key')
+      .then(res => res.json())
+      .then(cfg => {
+        const script = document.createElement('script');
+        script.src = `https://maps.googleapis.com/maps/api/js?key=${cfg.apiKey}&libraries=geometry,places`;
+        document.head.appendChild(script);
+      });
+  </script>
 <!-- SlickGrid CSS -->
 	   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/slickgrid@5.14.0/dist/styles/css/slick-alpine-theme.min.css">
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/slickgrid@5.14.0/dist/styles/css/slick.columnpicker.css"> 


### PR DESCRIPTION
## Summary
- load Google Maps API key from the server using an environment variable
- expose a new `/api/google-maps-key` endpoint
- dynamically load the Google Maps script in the client
- provide `.env.example` to document required env variable

## Testing
- `node --check api.js`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684182df27dc8330b0bf067aae2e081a