### PR TITLE
Fix env loading for Google Maps key

### DIFF
--- a/EcoMoveValencia/api.js
+++ b/EcoMoveValencia/api.js
@@ -3,6 +3,14 @@ import cors from 'cors';
 import path from 'path';
 import fetch from "node-fetch";
 import { fileURLToPath } from 'url';
+import fs from 'fs';
+import dotenv from 'dotenv';
+
+if (fs.existsSync('.env')) {
+  dotenv.config();
+} else if (fs.existsSync('.env.example')) {
+  dotenv.config({ path: '.env.example' });
+}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/EcoMoveValencia/package.json
+++ b/EcoMoveValencia/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "cors": "^2.8.5",
-    "node-fetch": "^2.6.7"
+    "node-fetch": "^2.6.7",
+    "dotenv": "^16.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- add dotenv dependency
- load environment variables from `.env` or `.env.example`

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684187a5f8ac83309ee3ec1f3353818e