### PR TITLE
Fix rodalia toggle when no train route

### DIFF
--- a/EcoMoveValencia/public/JSProyecto.js
+++ b/EcoMoveValencia/public/JSProyecto.js
@@ -1034,11 +1034,12 @@ function muestraRutaRodalia(){
 			            }
 						
 						
-						let dataString = JSON.stringify(respuesta);
-						
-						if (!dataString.includes("HEAVY_RAIL")){
-							mostrarPopupInfo(tm("ruta_rodalia_alternativa"), "info");
-						}
+                                                let dataString = JSON.stringify(respuesta);
+
+                                                const hasRodalia = dataString.includes("HEAVY_RAIL");
+                                                if (!hasRodalia){
+                                                        mostrarPopupInfo(tm("ruta_rodalia_alternativa"), "info");
+                                                }
 
 			            // Eliminar rutas previas del mapa
 			            if (routePolyline) {
@@ -1063,9 +1064,15 @@ function muestraRutaRodalia(){
 												    routePolyline.push(L.polyline(stepCoords, { color: step.travel_mode === "TRANSIT" ? "orange" : "green", weight: 4 }).addTo(map));
 												});
 						
-												document.getElementById("transport-select").value = "rodalia";
-												toggleTransport("rodalia", currentRouteCoords);
-												sincronizarSelectorPersonalizado("rodalia");
+                                                                               if(hasRodalia){
+                                                                                       document.getElementById("transport-select").value = "rodalia";
+                                                                                       toggleTransport("rodalia", currentRouteCoords);
+                                                                                       sincronizarSelectorPersonalizado("rodalia");
+                                                                               } else {
+                                                                                       document.getElementById("transport-select").value = "none";
+                                                                                       toggleTransport("none");
+                                                                                       sincronizarSelectorPersonalizado("none");
+                                                                               }
 
 						
 


### PR DESCRIPTION
## Summary
- avoid showing rodalia markers when there is no train service in the suggested route

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684193d2e6248330885342bdd88cf9a9