### PR TITLE
Add locale number formatting, dark mode, UI improvements and enrich AI prompt with km/min metrics

### DIFF
--- a/EcoMoveValencia/api.js
+++ b/EcoMoveValencia/api.js
@@ -334,6 +334,13 @@ app.post('/api/recommend-transport', async (req, res) => {
         contextoUsuario: userContext || 'Sin contexto adicional',
         candidatos: candidates
     };
+    const formatNumberEs = (value, decimals = 2) => Number(value || 0).toFixed(decimals).replace('.', ',');
+    const enrichCandidateForPrompt = (candidate) => ({
+        ...candidate,
+        distanceKm: formatNumberEs(candidate.totalDistance / 1000, 2),
+        timeMinutes: String(Math.round(candidate.totalTime / 60)),
+        co2Grams: formatNumberEs(candidate.co2, 2)
+    });
 
 
     const minMax = (values) => ({ min: Math.min(...values), max: Math.max(...values) });
@@ -462,7 +469,9 @@ Reglas:
 7) Usa modeLabel para nombrar los modos cuando exista.
 8) Nunca escribas el typo "BYCICLING".
 9) Para rutas largas (más de 6-7 km), evita sobrepriorizar micromovilidad (bici, Valenbisi, patinete) salvo que los datos lo justifiquen claramente.
-10) Cierra la explicación con una frase breve indicando si conviene transporte público y cuál sería la mejor alternativa de transporte público según los datos (si existe).`;
+10) Cierra la explicación con una frase breve indicando si conviene transporte público y cuál sería la mejor alternativa de transporte público según los datos (si existe).
+11) Expresa SIEMPRE tiempos en minutos (min) y distancias en kilómetros (km).
+12) Usa coma como separador decimal en CO2 (g) y cualquier métrica decimal (ej. 102,63 g; 5,43 km).`;
 
             const tieTolerance = 1e-9;
             const rankingTiempo = [...candidates]
@@ -491,14 +500,14 @@ Reglas:
             const explanationPrompt = {
                 ...userPrompt,
                 idiomaRespuesta: responseLanguage,
-                modoRecomendadoFijo: toLabeledCandidate(recommendedCandidate),
-                mejorTiempo: toLabeledCandidate(bestByTime),
-                mejorEmisiones: toLabeledCandidate(bestByCo2),
-                mejorDistancia: toLabeledCandidate(bestByDistance),
-                rankingTiempo: rankingTiempo.map(toLabeledCandidate),
-                rankingEmisiones: rankingEmisiones.map(toLabeledCandidate),
-                rankingDistancia: rankingDistancia.map(toLabeledCandidate),
-                mejorTransportePublico: bestPublicTransport ? toLabeledCandidate(bestPublicTransport) : null,
+                modoRecomendadoFijo: enrichCandidateForPrompt(toLabeledCandidate(recommendedCandidate)),
+                mejorTiempo: enrichCandidateForPrompt(toLabeledCandidate(bestByTime)),
+                mejorEmisiones: enrichCandidateForPrompt(toLabeledCandidate(bestByCo2)),
+                mejorDistancia: enrichCandidateForPrompt(toLabeledCandidate(bestByDistance)),
+                rankingTiempo: rankingTiempo.map(toLabeledCandidate).map(enrichCandidateForPrompt),
+                rankingEmisiones: rankingEmisiones.map(toLabeledCandidate).map(enrichCandidateForPrompt),
+                rankingDistancia: rankingDistancia.map(toLabeledCandidate).map(enrichCandidateForPrompt),
+                mejorTransportePublico: bestPublicTransport ? enrichCandidateForPrompt(toLabeledCandidate(bestPublicTransport)) : null,
                 empates: {
                     tiempo: empateTiempo.map(mode => ({ mode, modeLabel: labelByMode[mode] || mode })),
                     emisiones: empateEmisiones.map(mode => ({ mode, modeLabel: labelByMode[mode] || mode })),

--- a/EcoMoveValencia/public/JSProyecto.js
+++ b/EcoMoveValencia/public/JSProyecto.js
@@ -424,10 +424,26 @@ let inicio;
 		    return km * factor;
 		}
 
+		/* Funciones de formato común para distancia, tiempo y decimales con coma */
+		function formatDecimalLocale(value, decimals = 2) {
+		    const number = Number(value);
+		    if (!Number.isFinite(number)) return "0";
+		    return number.toFixed(decimals).replace(".", ",");
+		}
+
+		function formatDistanceKm(distanceMeters) {
+		    let km = Number(distanceMeters || 0) / 1000;
+		    return `${formatDecimalLocale(km, 2)} km`;
+		}
+
+		function formatTimeMinutes(totalSeconds) {
+		    const minutes = Math.round(Number(totalSeconds || 0) / 60);
+		    return `${minutes} min`;
+		}
+
 		/* Función para formatear la distancia: convierte metros a km con dos decimales */
 		function formatDistance(distanceMeters) {
-		    let km = distanceMeters / 1000;
-		    return km.toFixed(2) + " km";
+		    return formatDistanceKm(distanceMeters);
 		}
 
 		/* Función para formatear el tiempo.
@@ -564,16 +580,17 @@ function formatTime(totalSeconds) {
 			const existing = document.getElementById("aiRecommendationModal");
 			if (existing) existing.remove();
 
+			const darkMode = typeof window.isDarkModeEnabled === "function" && window.isDarkModeEnabled();
 			const modal = document.createElement("div");
 			modal.id = "aiRecommendationModal";
-			modal.style = "position:fixed;inset:0;background:rgba(15,23,42,0.52);display:flex;align-items:center;justify-content:center;z-index:2147483647;padding:16px;";
+			modal.style = `position:fixed;inset:0;background:${darkMode ? "rgba(2,6,23,0.75)" : "rgba(15,23,42,0.52)"};display:flex;align-items:center;justify-content:center;z-index:2147483647;padding:16px;`;
 
 			const card = document.createElement("div");
-			card.style = "position:relative;background:#ffffff;border-radius:16px;padding:16px;max-width:min(94vw,700px);width:100%;box-shadow:0 14px 38px rgba(2,6,23,0.25);";
+			card.style = `position:relative;background:${darkMode ? "#111827" : "#ffffff"};color:${darkMode ? "#e5e7eb" : "#111827"};border-radius:16px;padding:16px;max-width:min(94vw,700px);width:100%;box-shadow:0 14px 38px rgba(2,6,23,0.25);`;
 
 			const closeButton = document.createElement("button");
 			closeButton.textContent = "✖";
-			closeButton.style = "position:absolute;right:12px;top:8px;background:transparent;border:none;font-size:20px;cursor:pointer;color:#111827;";
+			closeButton.style = `position:absolute;right:12px;top:8px;background:transparent;border:none;font-size:20px;cursor:pointer;color:${darkMode ? "#e5e7eb" : "#111827"};`;
 
 			const content = document.createElement("div");
 			content.style = "display:flex;align-items:flex-end;gap:12px;padding-top:22px;";
@@ -587,7 +604,7 @@ function formatTime(totalSeconds) {
 			robotAvatar.style = "width:84px;height:84px;min-width:84px;border-radius:50%;background:#dbeafe;object-fit:cover;box-shadow:0 4px 12px rgba(30,64,175,0.15);";
 
 			const bubble = document.createElement("div");
-			bubble.style = "position:relative;flex:1;background:#eff6ff;border:1px solid #93c5fd;color:#1e3a8a;border-radius:14px;padding:14px;line-height:1.45;min-height:120px;";
+			bubble.style = `position:relative;flex:1;background:${darkMode ? "#1f2937" : "#eff6ff"};border:1px solid ${darkMode ? "#374151" : "#93c5fd"};color:${darkMode ? "#e5e7eb" : "#1e3a8a"};border-radius:14px;padding:14px;line-height:1.45;min-height:120px;`;
 
 			const bubbleTitle = document.createElement("div");
 			bubbleTitle.style = "font-weight:700;margin-bottom:6px;";
@@ -597,7 +614,7 @@ function formatTime(totalSeconds) {
 			const fullReason = String(aiRecommendation?.reason ?? t("ia_error")).trim() || t("ia_error");
 
 			const tail = document.createElement("div");
-			tail.style = "position:absolute;left:-9px;bottom:16px;width:18px;height:18px;background:#eff6ff;border-left:1px solid #93c5fd;border-bottom:1px solid #93c5fd;transform:rotate(45deg);";
+			tail.style = `position:absolute;left:-9px;bottom:16px;width:18px;height:18px;background:${darkMode ? "#1f2937" : "#eff6ff"};border-left:1px solid ${darkMode ? "#374151" : "#93c5fd"};border-bottom:1px solid ${darkMode ? "#374151" : "#93c5fd"};transform:rotate(45deg);`;
 
 			bubble.appendChild(bubbleTitle);
 			bubble.appendChild(bubbleReason);
@@ -611,11 +628,14 @@ function formatTime(totalSeconds) {
 
 			const understoodButton = document.createElement("button");
 			understoodButton.textContent = t("ia_entendido");
-			understoodButton.style = "background:#e5e7eb;color:#111827;border:none;border-radius:10px;padding:8px 12px;cursor:pointer;";
+			understoodButton.style = `background:${darkMode ? "#374151" : "#e5e7eb"};color:${darkMode ? "#e5e7eb" : "#111827"};border:none;border-radius:10px;padding:8px 12px;cursor:pointer;`;
 
 			const routeButton = document.createElement("button");
 			routeButton.textContent = t("ia_ver_ruta");
 			routeButton.style = "background:#10b981;color:#fff;border:none;border-radius:10px;padding:8px 12px;cursor:pointer;display:none;";
+			const poweredBy = document.createElement("div");
+			poweredBy.textContent = "Powered by OpenAI";
+			poweredBy.style = `font-size:11px;opacity:0.75;margin-top:8px;text-align:right;color:${darkMode ? "#9ca3af" : "#6b7280"};`;
 
 			let typingIndex = 0;
 			let mouthToggle = false;
@@ -655,6 +675,7 @@ function formatTime(totalSeconds) {
 			card.appendChild(closeButton);
 			card.appendChild(content);
 			card.appendChild(modalActions);
+			card.appendChild(poweredBy);
 			modal.appendChild(card);
 			document.body.appendChild(modal);
 		}
@@ -687,19 +708,20 @@ function formatTime(totalSeconds) {
 		}
 
 		async function renderComparisonSlickGrid(results) {
+			const darkMode = typeof window.isDarkModeEnabled === "function" && window.isDarkModeEnabled();
 		    let modal = document.createElement("div");
 		    modal.id = "comparisonModal";
 		    modal.style = "position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1000;";
 
 		    let modalContent = document.createElement("div");
 			const isMobile = window.innerWidth <= 768;
-			modalContent.style = `background-color:#fff;padding:20px;border-radius:8px;position:relative;box-sizing:border-box;width:${isMobile ? "95vw" : "1300px"};max-height:94vh;`;
+			modalContent.style = `background-color:${darkMode ? "#111827" : "#fff"};color:${darkMode ? "#e5e7eb" : "#111827"};padding:20px;border-radius:8px;position:relative;box-sizing:border-box;width:${isMobile ? "95vw" : "1300px"};max-height:94vh;`;
 
 		    let closeButton = document.createElement("button");
 		    closeButton.textContent = "✖";
-		    closeButton.style = "position: absolute; top: 10px; right: 10px; border: none; background: transparent; font-size: 20px; cursor: pointer; color: #000;";
+		    closeButton.style = `position: absolute; top: 10px; right: 10px; border: none; background: transparent; font-size: 20px; cursor: pointer; color: ${darkMode ? "#e5e7eb" : "#000"};`;
 		    closeButton.onmouseover = () => closeButton.style.color = "red";
-		    closeButton.onmouseout = () => closeButton.style.color = "#000";
+		    closeButton.onmouseout = () => closeButton.style.color = darkMode ? "#e5e7eb" : "#000";
 		    closeButton.onclick = () => {
 				if (document.body.contains(modal)) document.body.removeChild(modal);
 				removeFloatingAiButton();
@@ -720,6 +742,29 @@ function formatTime(totalSeconds) {
 				style = document.createElement("style");
 				style.id = "comparison-grid-style";
 				style.textContent = `
+				#comparisonModal .slick-header-columns {
+					background: #f3f4f6 !important;
+				}
+				#comparisonModal .slick-row,
+				#comparisonModal .slick-cell,
+				#comparisonModal .slick-header-column {
+					color: #111827 !important;
+				}
+				#comparisonModal .slick-cell {
+					background: #ffffff !important;
+				}
+				#comparisonModal.dark-mode .slick-header-columns {
+					background: #1f2937 !important;
+				}
+				#comparisonModal.dark-mode .slick-row,
+				#comparisonModal.dark-mode .slick-cell,
+				#comparisonModal.dark-mode .slick-header-column {
+					color: #e5e7eb !important;
+				}
+				#comparisonModal.dark-mode .slick-cell {
+					background: #0f172a !important;
+					border-color: #334155 !important;
+				}
 			    .slick-header-column {
 			        height: 40px !important;
 			        line-height: 40px !important;
@@ -738,6 +783,7 @@ function formatTime(totalSeconds) {
 			`;
 				document.head.appendChild(style);
 			}
+			modal.classList.toggle("dark-mode", darkMode);
 		    document.body.appendChild(modal);
 
 
@@ -784,16 +830,16 @@ function formatTime(totalSeconds) {
 		            route: "-"
 		        } : {
 		            mode: modeTranslations[idiomaActual][item.mode] || item.mode,
-		            distance: item.totalDistance ? `${(item.totalDistance / 1000).toFixed(2)} km` : "-",
+		            distance: item.totalDistance ? formatDistanceKm(item.totalDistance) : "-",
                             time: item.totalTime ? formatGridTime(item.totalTime) : "-",
-		            co2: item.co2 ? item.co2.toFixed(2) : "0",
+		            co2: Number.isFinite(item.co2) ? formatDecimalLocale(item.co2, 2) : "0,00",
 		            detail: groupSubRoutes(item.subRoutes, item.mode),
 		            route: item
 		        };
 		    });
 			
 
-		    data.sort((a, b) => parseFloat(a.co2 || 0) - parseFloat(b.co2 || 0));
+		    data.sort((a, b) => parseFloat(String(a.co2 || 0).replace(",", ".")) - parseFloat(String(b.co2 || 0).replace(",", ".")));
 
 		    var grid = new Slick.Grid("#gridContainer", data, columns, options);
 
@@ -878,8 +924,8 @@ function formatTime(totalSeconds) {
 		                valA = timeToSeconds(valA);
 		                valB = timeToSeconds(valB);
 		            } else if (field === "co2" || field === "distance") {
-		                valA = parseFloat(valA) || 0;
-		                valB = parseFloat(valB) || 0;
+		                valA = parseFloat(String(valA).replace(",", ".")) || 0;
+		                valB = parseFloat(String(valB).replace(",", ".")) || 0;
 		            }
 
 		            return isAscending ? valA - valB : valB - valA;
@@ -945,26 +991,13 @@ function formatTime(totalSeconds) {
                 // Formatear el tiempo mostrado en la tabla SlickGrid
                 // Si supera los 60 minutos, se convierte a horas y minutos
                 function formatGridTime(totalSeconds) {
-                    let minutes = Math.round(totalSeconds / 60);
-                    if (minutes >= 60) {
-                        let hours = Math.floor(minutes / 60);
-                        let remaining = minutes % 60;
-                        return `${hours}h ${remaining}min`;
-                    }
-                    return `${minutes}min`;
+                    return formatTimeMinutes(totalSeconds);
                 }
 
 function timeToSeconds(timeStr) {
     if (!timeStr) return 0;
-    let parts = String(timeStr).trim().split(" ");
-    let minutes = 0, seconds = 0;
-    if (parts.length === 2) {
-        minutes = parseInt(parts[0], 10);
-        seconds = parseInt(parts[1], 10);
-    } else {
-        seconds = parseInt(parts[0], 10);
-    }
-    return (minutes * 60) + seconds;
+    const minutes = parseFloat(String(timeStr).replace(",", "."));
+    return Number.isFinite(minutes) ? minutes * 60 : 0;
 }
 
         
@@ -1818,25 +1851,26 @@ function muestraRutaTaxi(){
 
   if (modeType === "PATINETE") totalDuration *= 0.78;
 
+  const darkMode = typeof window.isDarkModeEnabled === "function" && window.isDarkModeEnabled();
   const modal = document.createElement("div");
   modal.id = "googleMapsModal";
-  modal.style = `position:fixed;${window.innerWidth<=758?"top:10vh;left:5vw;width:90vw;font-size:4vw;":"top:10vh;right:20px;width:390px;font-size:16px;"}max-height:80vh;background:white;z-index:10000;overflow-y:auto;box-shadow:0 8px 16px rgba(0,0,0,0.25);border-radius:12px;padding:20px;font-family:Arial,sans-serif;`;
+  modal.style = `position:fixed;${window.innerWidth<=758?"top:10vh;left:5vw;width:90vw;font-size:4vw;":"top:10vh;right:20px;width:390px;font-size:16px;"}max-height:80vh;background:${darkMode ? "#0f172a" : "white"};color:${darkMode ? "#e5e7eb" : "#111827"};z-index:10000;overflow-y:auto;box-shadow:0 8px 16px rgba(0,0,0,0.25);border-radius:12px;padding:20px;font-family:Arial,sans-serif;`;
 
   modal.innerHTML = `
     <button id="closeModal" style="position:absolute;top:10px;right:10px;width:30px;height:30px;background:#ef4444;color:white;border:none;border-radius:50%;font-size:20px;cursor:pointer;box-shadow:0 2px 5px rgba(0,0,0,0.3);display:flex;align-items:center;justify-content:center;">&times;</button>
-    <h2 style="margin-bottom:15px;border-bottom:2px solid #10b981;padding-bottom:5px;color:#333;">${td("detalle_tramos")}</h2>
+    <h2 style="margin-bottom:15px;border-bottom:2px solid #10b981;padding-bottom:5px;color:${darkMode ? "#e5e7eb" : "#333"};">${td("detalle_tramos")}</h2>
     <div style="margin-bottom:15px;line-height:1.6;">
-      <p><strong>${td("distancia_total")}:</strong> ${(totalDistance/1000).toFixed(2)} km</p>
-      <p><strong>${td("tiempo_total")}:</strong> ${(totalDuration/60).toFixed(0)} mins</p>
-      <p><strong>${td("co2_total")}:</strong> ${totalEmissions.toFixed(2)} g</p>
+      <p><strong>${td("distancia_total")}:</strong> ${formatDistanceKm(totalDistance)}</p>
+      <p><strong>${td("tiempo_total")}:</strong> ${formatTimeMinutes(totalDuration)}</p>
+      <p><strong>${td("co2_total")}:</strong> ${formatDecimalLocale(totalEmissions, 2)} g</p>
     </div>
-    <h3 style="margin-bottom:10px;color:#555;">${td("detalle_tramos2")}</h3>
+    <h3 style="margin-bottom:10px;color:${darkMode ? "#cbd5e1" : "#555"};">${td("detalle_tramos2")}</h3>
     ${Object.keys(travelModes).map(modeKey => `
-      <div style="background:#f9fafb;margin-bottom:10px;padding:10px;border-radius:8px;box-shadow:0 1px 4px rgba(0,0,0,0.1);">
+      <div style="background:${darkMode ? "#1f2937" : "#f9fafb"};margin-bottom:10px;padding:10px;border-radius:8px;box-shadow:0 1px 4px rgba(0,0,0,0.1);">
         <p><strong>${tt("modo")}:</strong> ${modeTranslations[modeKey] || modeMap[modeKey] || modeKey}</p>
-        <p><strong>${tt("distancia")}:</strong> ${(travelModes[modeKey].distance/1000).toFixed(2)} km</p>
-        <p><strong>${tt("tiempo")}:</strong> ${(travelModes[modeKey].duration/60).toFixed(0)} mins</p>
-        <p><strong>${tt("co2")}:</strong> ${travelModes[modeKey].emissions.toFixed(2)} g</p>
+        <p><strong>${tt("distancia")}:</strong> ${formatDistanceKm(travelModes[modeKey].distance)}</p>
+        <p><strong>${tt("tiempo")}:</strong> ${formatTimeMinutes(travelModes[modeKey].duration)}</p>
+        <p><strong>${tt("co2")}:</strong> ${formatDecimalLocale(travelModes[modeKey].emissions, 2)} g</p>
       </div>`).join('')}`;
 
   document.body.appendChild(modal);

--- a/EcoMoveValencia/public/index.html
+++ b/EcoMoveValencia/public/index.html
@@ -169,6 +169,72 @@
     border-radius: 5px;
     z-index: 1000;
 }
+
+.theme-toggle-btn {
+    position: fixed;
+    top: 3%;
+    right: 220px;
+    z-index: 1000;
+    background-color: #ffffff;
+    background-image: url("img/luna.png");
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 18px 18px;
+    border: 1px solid #d1d5db;
+    border-radius: 50%;
+    width: 38px;
+    height: 38px;
+    padding: 0;
+    font-size: 0;
+    line-height: 0;
+    cursor: pointer;
+}
+
+.theme-toggle-btn.is-dark {
+    background-image: url("img/sol.png");
+    background-color: #111827;
+    border-color: #4b5563;
+}
+
+body.dark-mode {
+    background: #0b1220;
+    color: #e5e7eb;
+}
+
+body.dark-mode .logo {
+    opacity: 1;
+    filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.35));
+}
+
+body.dark-mode .distance-info,
+body.dark-mode .idiomdiv,
+body.dark-mode .custom-select-header,
+body.dark-mode .custom-select-options,
+body.dark-mode .transport-selector {
+    background: #111827 !important;
+    color: #e5e7eb !important;
+    border-color: #374151 !important;
+}
+
+body.dark-mode .custom-select-option:hover {
+    background-color: #1f2937;
+}
+
+body.dark-mode .directions {
+    background: rgba(17, 24, 39, 0.9);
+}
+
+body.dark-mode .input-container input {
+    background: #0f172a;
+    color: #e5e7eb;
+    border-color: #374151;
+}
+
+body.dark-mode .leaflet-popup-content-wrapper,
+body.dark-mode .leaflet-popup-tip {
+    background: #0f172a;
+    color: #e5e7eb;
+}
     
 
 	
@@ -693,6 +759,7 @@
   <img src="img/val.jpg" alt="Valenciano" class="bandera val">
   <img src="img/en.png" alt="English" class="bandera en">
 </div>
+<button id="themeToggleBtn" class="theme-toggle-btn" aria-label="Cambiar tema"></button>
 
    <!-- Select nativo oculto (para accesibilidad) -->
   <select id="transport-select" class="native-select">
@@ -1202,11 +1269,36 @@ let map = L.map('map', {
     maxBounds: [[39.059009, -1.437558], [39.937940, 0.747262]]
 }).setView([39.4699, -0.3763], 13);
 
-// Capa base de Tracestack Topo
-L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
-    maxZoom: 19,
-   
-}).addTo(map);
+const lightTileUrl = 'https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png';
+const darkTileUrl = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+let activeTileLayer = null;
+
+function applyMapTheme(isDarkMode) {
+    if (activeTileLayer) {
+        map.removeLayer(activeTileLayer);
+    }
+    activeTileLayer = L.tileLayer(isDarkMode ? darkTileUrl : lightTileUrl, { maxZoom: 19 });
+    activeTileLayer.addTo(map);
+}
+
+window.isDarkModeEnabled = () => document.body.classList.contains("dark-mode");
+
+const savedTheme = localStorage.getItem("themeMode") === "dark";
+if (savedTheme) document.body.classList.add("dark-mode");
+applyMapTheme(savedTheme);
+
+const themeToggleBtn = document.getElementById("themeToggleBtn");
+function refreshThemeButton() {
+    const darkEnabled = window.isDarkModeEnabled();
+    themeToggleBtn.classList.toggle("is-dark", darkEnabled);
+}
+themeToggleBtn.addEventListener("click", () => {
+    const darkEnabled = document.body.classList.toggle("dark-mode");
+    localStorage.setItem("themeMode", darkEnabled ? "dark" : "light");
+    applyMapTheme(darkEnabled);
+    refreshThemeButton();
+});
+refreshThemeButton();
 
     let pointA = null;
     let pointB = null;
@@ -1308,6 +1400,7 @@ L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
     });
     
     function seleccionaOpcionTransporte() {
+        const darkMode = typeof window.isDarkModeEnabled === "function" && window.isDarkModeEnabled();
         // Crear el modal
         let modal = document.createElement("div");
         modal.style.position = "fixed";
@@ -1315,7 +1408,7 @@ L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
         modal.style.left = "0";
         modal.style.width = "100%";
         modal.style.height = "100%";
-        modal.style.backgroundColor = "rgba(0, 0, 0, 0.5)";
+        modal.style.backgroundColor = darkMode ? "rgba(2, 6, 23, 0.78)" : "rgba(0, 0, 0, 0.5)";
         modal.style.display = "flex";
         modal.style.justifyContent = "center";
         modal.style.alignItems = "center";
@@ -1323,7 +1416,8 @@ L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
         modal.style.animation = "fadeIn 0.3s ease-in-out";
 
         let modalContent = document.createElement("div");
-        modalContent.style.background = "#fff";
+        modalContent.style.background = darkMode ? "#111827" : "#fff";
+        modalContent.style.color = darkMode ? "#e5e7eb" : "#111827";
         modalContent.style.padding = "20px";
         modalContent.style.borderRadius = "10px";
         modalContent.style.textAlign = "center";
@@ -1342,6 +1436,7 @@ L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
         	} 
         let title = document.createElement("h3");
         title.innerText = tm("selecciona_transporte");
+        title.style.color = darkMode ? "#f3f4f6" : "#111827";
 
         modalContent.appendChild(title);
 
@@ -1397,6 +1492,7 @@ L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
             let texto = document.createElement("span");
             texto.innerText = modeTranslations[idiomaActual][boton.clave] || modeMap[boton.valor] || boton.valor;
             texto.style.marginTop = "5px";
+            texto.style.color = darkMode ? "#e5e7eb" : "#111827";
 
             btn.appendChild(img);
             btn.appendChild(texto);
@@ -1440,6 +1536,7 @@ L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
         let textoComparar = document.createElement("span");
         textoComparar.innerText = t("comparar");
         textoComparar.style.marginLeft = "10px";
+        textoComparar.style.color = darkMode ? "#e5e7eb" : "#111827";
         
         comparacion.appendChild(imgComparar);
         comparacion.appendChild(textoComparar);


### PR DESCRIPTION
### Motivation
- Ensure AI explanations use consistent units and Spanish/Valencian locale decimal format when defending recommendations.
- Improve UX by adding dark mode support, a theme toggle, and visual refinements for AI and comparison modals.
- Normalize number/time formatting across the UI and data sent to the language model to avoid mismatches and parsing issues.

### Description
- Backend (`EcoMoveValencia/api.js`): added `formatNumberEs` and `enrichCandidateForPrompt` to include `distanceKm`, `timeMinutes` and `co2Grams` in the explanation prompt and extended `systemPrompt` with rules to require minutes/km units and comma decimals.
- Frontend formatting (`public/JSProyecto.js`): introduced `formatDecimalLocale`, `formatDistanceKm`, `formatTimeMinutes`, updated grid/co2 formatting and sorting to handle comma decimals, and simplified time parsing to use minutes as numeric values.
- Dark mode and UI polish (`public/JSProyecto.js` and `public/index.html`): added a theme toggle button, body-level `dark-mode` styles, map tile switching for light/dark themes, many modal and component style adaptations for dark mode, and a small "Powered by OpenAI" label in the AI modal. 
- Miscellaneous UI fixes: updated AI recommendation modal behavior and visuals, improved comparison modal CSS and highlighting, and standardized metric displays (km, min, g) across route detail modals and SlickGrid.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce66a0df448330a848a69976954b24)