### PR TITLE
Fix dark mode toggle on index and align sun/moon icons

### DIFF
--- a/EcoMoveValencia/public/index.html
+++ b/EcoMoveValencia/public/index.html
@@ -177,7 +177,7 @@
     z-index: 1000;
 
     background-color: #ffffff;
-    background-image: url("img/luna.png");
+    background-image: url("img/icons8-sol-200.gif");
     background-repeat: no-repeat;
     background-position: center;
     background-size: 18px 18px;
@@ -192,7 +192,7 @@
 }
 
 .theme-toggle-btn.is-dark {
-    background-image: url("img/sol.png");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23f8fafc' d='M20.742 13.045A9 9 0 1 1 10.955 3.258a1 1 0 0 1 1.087 1.32A7 7 0 1 0 19.42 11.958a1 1 0 0 1 1.322 1.087z'/%3E%3C/svg%3E");
     background-color: #111827;
     border-color: #4b5563;
 }
@@ -763,8 +763,6 @@ body.dark-mode .leaflet-popup-tip {
   <img src="img/val.jpg" alt="Valenciano" class="bandera val">
   <img src="img/en.png" alt="English" class="bandera en">
 </div>
-<button id="themeToggleBtn" class="theme-toggle-btn" aria-label="Cambiar tema"></button>
-
 <button id="themeToggleBtn" class="theme-toggle-btn" aria-label="Cambiar tema"></button>
 
 

--- a/EcoMoveValencia/public/information.html
+++ b/EcoMoveValencia/public/information.html
@@ -72,6 +72,10 @@
     .theme-toggle-btn.is-dark {
       background-color: #111827;
       border-color: #4b5563;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23f8fafc' d='M20.742 13.045A9 9 0 1 1 10.955 3.258a1 1 0 0 1 1.087 1.32A7 7 0 1 0 19.42 11.958a1 1 0 0 1 1.322 1.087z'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: 18px 18px;
     }
     .bandera {
       width: 40px;


### PR DESCRIPTION
### Motivation
- The dark mode toggle on the main page did not reliably activate because there were duplicate `#themeToggleBtn` elements and icon state was inconsistent between `index.html` and `information.html`.
- The UI requires the sun animation (GIF) to represent light mode and a moon icon for dark mode, and both pages should reflect the same behavior.

### Description
- Removed the duplicate `<button id="themeToggleBtn">` in `public/index.html` so a single button receives click events and toggles the theme reliably.
- Updated `public/index.html` CSS to use the existing `img/icons8-sol-200.gif` for the light-state button and an inline SVG moon as the `background-image` for `.theme-toggle-btn.is-dark` to show the moon in dark mode.
- Added matching inline moon icon properties (`background-repeat`, `background-position`, `background-size`) to `public/information.html` so both pages display the same sun/moon behavior.
- Kept existing `localStorage` read/write logic intact so theme persistence is unchanged.

### Testing
- Ran `rg -n 'id="themeToggleBtn"' public/index.html` to confirm only one `#themeToggleBtn` remains and the search succeeded.
- Ran `rg -n 'theme-toggle-btn\.is-dark|icons8-sol-200\.gif' public/index.html public/information.html` to verify the icon resources and CSS changes and the search succeeded.
- Verified diffs with `git -C . diff --stat` and committed changes with `git -C . commit` which reported a successful commit.
- All automated checks executed above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1ff5da7c83308474ef7d4dce8e06)