### PR TITLE
Hide Google Maps key exposure and move geocoding to the backend

### DIFF
--- a/EcoMoveValencia/api.js
+++ b/EcoMoveValencia/api.js
@@ -62,10 +62,54 @@ app.use(express.json()); // Asegura que el body se maneje como JSON
 app.use(express.urlencoded({ extended: true }));
 app.use(express.static(path.join(__dirname, 'public')));
 
-// Endpoint para proporcionar la clave de Google Maps al cliente
-app.get('/api/google-maps-key', (req, res) => {
+app.get('/api/geocode', async (req, res) => {
     res.setHeader('Content-Type', 'application/json');
-    res.json({ apiKey });
+    const address = (req.query.address || "").toString().trim();
+    if (!address) {
+        return res.status(400).json({ error: "El parámetro address es obligatorio" });
+    }
+
+    try {
+        const params = new URLSearchParams({
+            q: address,
+            format: "jsonv2",
+            limit: "1",
+            countrycodes: "es",
+            bounded: "1",
+            viewbox: "-0.75,39.9,0.1,39.0"
+        });
+        const url = `https://nominatim.openstreetmap.org/search?${params.toString()}`;
+        const response = await fetch(url, {
+            headers: {
+                "User-Agent": "EcoMoveValencia/1.0 (geocoding)"
+            }
+        });
+
+        if (!response.ok) {
+            return res.status(502).json({ error: "Error al consultar el geocodificador" });
+        }
+
+        const data = await response.json();
+        const first = Array.isArray(data) ? data[0] : null;
+        if (!first) {
+            return res.status(404).json({ error: "No se encontraron resultados" });
+        }
+
+        const lat = Number(first.lat);
+        const lng = Number(first.lon);
+        if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+            return res.status(502).json({ error: "Respuesta inválida del geocodificador" });
+        }
+
+        return res.json({
+            lat,
+            lng,
+            displayName: first.display_name || address
+        });
+    } catch (error) {
+        console.error("Error en /api/geocode:", error);
+        return res.status(500).json({ error: "Error interno del servidor" });
+    }
 });
 // Ruta de prueba
 app.get('/api/getBicis', (req, res) => {

--- a/EcoMoveValencia/public/JSProyecto.js
+++ b/EcoMoveValencia/public/JSProyecto.js
@@ -7,9 +7,6 @@ let inicio;
         function calculateDistanceAndRoute() {
           if (!pointA || !pointB) return;
 
-          const origin = new google.maps.LatLng(pointA.lat, pointA.lng);
-          const destination = new google.maps.LatLng(pointB.lat, pointB.lng);
-
 		  if (transportMode === "COMPARA") {
 			inicio = performance.now();
 		      let modes = ["WALKING", "DRIVING", "BICYCLING", "PATINETE", "Valenbisi", "METRO", "BUS", "TRAIN", "ELECTRIC_MOTORBIKE", "TAXI"];
@@ -2538,22 +2535,12 @@ function muestraRutaDesdeTabla(respuesta){
 const originInput = document.getElementById("origin-input");
 const destinationInput = document.getElementById("destination-input");
 
-let originAutocomplete;
-let destinationAutocomplete;
-let directionsService;
-let distanceService;
-
-function initGoogleApis() {
-    directionsService = new google.maps.DirectionsService();
-    distanceService = new google.maps.DistanceMatrixService();
-    originAutocomplete = new google.maps.places.Autocomplete(originInput);
-    destinationAutocomplete = new google.maps.places.Autocomplete(destinationInput);
-}
-
-if (window.google && window.google.maps && window.google.maps.places) {
-    initGoogleApis();
-} else {
-    window.addEventListener('google-maps-loaded', initGoogleApis);
+async function geocodeAddress(address) {
+  const response = await fetch(`/api/geocode?address=${encodeURIComponent(address)}`);
+  if (!response.ok) {
+    return null;
+  }
+  return response.json();
 }
 
 const minLat = 39.00, maxLat = 39.9;
@@ -2567,7 +2554,7 @@ function isWithinBounds(latlng) {
 }
 
 // Cuando se hace click en el botón "Establecer dirección"
-document.getElementById("set-directions").addEventListener("click", function() {
+document.getElementById("set-directions").addEventListener("click", async function() {
 	
 	
 	console.log(window.innerWidth);
@@ -2597,58 +2584,43 @@ document.getElementById("set-directions").addEventListener("click", function() {
     return;
   }
 
-  const geocoder = new google.maps.Geocoder();
+  const originData = await geocodeAddress(originAddress);
+  if (!originData) {
+    mostrarPopupInfo(tm("selecciona_origen"), "error");
+    return;
+  }
 
-  // Geocode para la dirección de origen
-  geocoder.geocode({ address: originAddress }, function(results, status) {//
-    if (status === google.maps.GeocoderStatus.OK && results[0]) {
-      const originLocation = results[0].geometry.location;
-      // Convierte la posición de Google a un objeto LatLng de Leaflet
-      pointA = L.latLng(originLocation.lat(), originLocation.lng());
+  pointA = L.latLng(originData.lat, originData.lng);
+  if (markerA) {
+    map.removeLayer(markerA);
+  }
 
-      // Si ya existe un marker, se elimina
-      if (markerA) {
-        map.removeLayer(markerA);
-      }
-      
-      if (!isWithinBounds(pointA)) {
-          mostrarPopupInfo(tm("fuera_limites_origen"), "error");
-          return;
-      }
-      
-      markerA = createMarker(pointA, "red");
+  if (!isWithinBounds(pointA)) {
+    mostrarPopupInfo(tm("fuera_limites_origen"), "error");
+    return;
+  }
+  markerA = createMarker(pointA, "red");
 
-      // Geocode para la dirección de destino
-      geocoder.geocode({ address: destinationAddress }, function(results2, status2) {
-        if (status2 === google.maps.GeocoderStatus.OK && results2[0]) {
-          const destinationLocation = results2[0].geometry.location;
-          pointB = L.latLng(destinationLocation.lat(), destinationLocation.lng());
+  const destinationData = await geocodeAddress(destinationAddress);
+  if (!destinationData) {
+    mostrarPopupInfo(tm("selecciona_destino"), "error");
+    return;
+  }
 
-          
-          if (!isWithinBounds(pointB)) {
-               mostrarPopupInfo(tm("fuera_limites_destino"), "error");
-              return;
-          }
-	        
-          if (markerB) {
-            map.removeLayer(markerB);
-          }
-          markerB = createMarker(pointB, "blue");
+  pointB = L.latLng(destinationData.lat, destinationData.lng);
+  if (!isWithinBounds(pointB)) {
+    mostrarPopupInfo(tm("fuera_limites_destino"), "error");
+    return;
+  }
 
-          document.getElementById("distance-info").innerText = "Origen y destino establecidos.";
-          // Centrar el mapa entre ambos puntos
-          moveToMidPointMarkers(pointA, pointB);
+  if (markerB) {
+    map.removeLayer(markerB);
+  }
+  markerB = createMarker(pointB, "blue");
 
-          // Opcional: Llama a la función para calcular/dibujar la ruta según la opción de transporte
-          seleccionaOpcionTransporte();
-        } else {
-           mostrarPopupInfo(tm("selecciona_destino"), "error");
-        }
-      });
-    } else {
-      mostrarPopupInfo(tm("selecciona_origen"), "error");
-    }
-  });
+  document.getElementById("distance-info").innerText = "Origen y destino establecidos.";
+  moveToMidPointMarkers(pointA, pointB);
+  seleccionaOpcionTransporte();
 });
 
 

--- a/EcoMoveValencia/public/index.html
+++ b/EcoMoveValencia/public/index.html
@@ -858,18 +858,6 @@ body.dark-mode .leaflet-popup-tip {
   <!-- Incluir iconos de Lucide -->
   <script src="https://unpkg.com/lucide@latest"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-  <script>
-    // Carga dinámica de Google Maps con la clave obtenida del servidor
-    fetch('/api/google-maps-key')
-      .then(res => res.json())
-      .then(cfg => {
-        const script = document.createElement('script');
-        script.src = `https://maps.googleapis.com/maps/api/js?key=${cfg.apiKey}&libraries=geometry,places`;
-        script.async = true;
-        script.onload = () => window.dispatchEvent(new Event('google-maps-loaded'));
-        document.head.appendChild(script);
-      });
-  </script>
 <!-- SlickGrid CSS -->
 	   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/slickgrid@5.14.0/dist/styles/css/slick-alpine-theme.min.css">
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/slickgrid@5.14.0/dist/styles/css/slick.columnpicker.css"> 


### PR DESCRIPTION
### Motivation
- Prevent the Google Maps API key from being exposed in browser DevTools (Network/Sources/Console) when loading the app.
- Move address geocoding off the client to avoid any client-side calls that would leak sensitive keys or allow discovery via page source.
- Keep server-side routing/directions functionality but reduce surface area by returning only lat/lng to the frontend for mapping actions.

### Description
- Removed dynamic client-side loading of the Google Maps JS SDK from `public/index.html` so the API key is no longer requested from the browser.
- Added a backend endpoint `GET /api/geocode` in `api.js` that queries Nominatim (OpenStreetMap) and returns `{ lat, lng, displayName }` for a supplied `address` query parameter.
- Replaced client-side use of `google.maps.Geocoder` / `places.Autocomplete` in `public/JSProyecto.js` with `fetch('/api/geocode?address=...')` and updated the `set-directions` flow to use the backend geocoding results to place markers and trigger routing.
- Retained server-side `GOOGLE_MAPS_API_KEY` usage for Directions/Distance Matrix server endpoints, but the key is no longer sent to or requested by the browser.

### Testing
- Ran `node --check api.js` which succeeded and found no syntax errors.
- Ran `node --check public/JSProyecto.js` which succeeded and found no syntax errors.
- Ran a repository search for client-side Google Maps usage with `rg -n "google\.maps|google-maps-key|maps/api/js\?key"` which returned no matches in the frontend files, confirming the SDK load was removed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2f10873c8330b87374f907dbf44f)