### PR TITLE
Restore Google Places flow for typed origin/destination selection

### DIFF
--- a/EcoMoveValencia/api.js
+++ b/EcoMoveValencia/api.js
@@ -62,6 +62,12 @@ app.use(express.json()); // Asegura que el body se maneje como JSON
 app.use(express.urlencoded({ extended: true }));
 app.use(express.static(path.join(__dirname, 'public')));
 
+// Endpoint para proporcionar la clave de Google Maps al cliente
+app.get('/api/google-maps-key', (req, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    res.json({ apiKey });
+});
+
 async function nominatimSearch(params) {
     await waitForNominatimSlot();
     const url = `https://nominatim.openstreetmap.org/search?${params.toString()}`;

--- a/EcoMoveValencia/public/JSProyecto.js
+++ b/EcoMoveValencia/public/JSProyecto.js
@@ -2534,126 +2534,23 @@ function muestraRutaDesdeTabla(respuesta){
 
 const originInput = document.getElementById("origin-input");
 const destinationInput = document.getElementById("destination-input");
-const selectedAddressCoords = new Map();
+let originAutocomplete;
+let destinationAutocomplete;
+let directionsService;
+let distanceService;
 
-async function geocodeAddress(address) {
-  const normalizedAddress = (address || "").trim();
-  if (!normalizedAddress) return null;
-  if (selectedAddressCoords.has(normalizedAddress)) {
-    return selectedAddressCoords.get(normalizedAddress);
-  }
-
-  const response = await fetch(`/api/geocode?address=${encodeURIComponent(normalizedAddress)}`);
-  if (!response.ok) {
-    return null;
-  }
-  const data = await response.json();
-  selectedAddressCoords.set(normalizedAddress, data);
-  return data;
+function initGoogleApis() {
+    directionsService = new google.maps.DirectionsService();
+    distanceService = new google.maps.DistanceMatrixService();
+    originAutocomplete = new google.maps.places.Autocomplete(originInput);
+    destinationAutocomplete = new google.maps.places.Autocomplete(destinationInput);
 }
 
-function setupAddressAutocomplete(inputElement) {
-  const parent = inputElement.closest(".input-container");
-  if (!parent) return;
-
-  const dropdown = document.createElement("div");
-  dropdown.className = "suggestions-dropdown";
-  dropdown.style.display = "none";
-  parent.appendChild(dropdown);
-
-  let debounceTimer;
-  let currentSuggestions = [];
-
-  function renderSuggestions(suggestions) {
-    currentSuggestions = suggestions;
-    dropdown.innerHTML = "";
-    if (!suggestions.length) {
-      dropdown.style.display = "none";
-      return;
-    }
-
-    suggestions.forEach((suggestion, index) => {
-      const item = document.createElement("div");
-      item.className = "suggestions-item";
-      item.textContent = suggestion.displayName;
-      item.addEventListener("click", () => {
-        inputElement.value = suggestion.displayName;
-        selectedAddressCoords.set(suggestion.displayName, {
-          lat: suggestion.lat,
-          lng: suggestion.lng,
-          displayName: suggestion.displayName
-        });
-        dropdown.style.display = "none";
-      });
-      if (index === 0) item.classList.add("active");
-      dropdown.appendChild(item);
-    });
-
-    dropdown.style.display = "block";
-  }
-
-  inputElement.addEventListener("input", () => {
-    clearTimeout(debounceTimer);
-    const value = inputElement.value.trim();
-    if (value.length < 3) {
-      renderSuggestions([]);
-      return;
-    }
-
-    debounceTimer = setTimeout(async () => {
-      try {
-        const response = await fetch(`/api/geocode/suggest?q=${encodeURIComponent(value)}`);
-        if (!response.ok) {
-          renderSuggestions([]);
-          return;
-        }
-
-        const suggestions = await response.json();
-        suggestions.forEach(suggestion => {
-          selectedAddressCoords.set(suggestion.displayName, {
-            lat: suggestion.lat,
-            lng: suggestion.lng,
-            displayName: suggestion.displayName
-          });
-        });
-        renderSuggestions(suggestions);
-      } catch (error) {
-        console.error("Error cargando sugerencias de dirección:", error);
-        renderSuggestions([]);
-      }
-    }, 250);
-  });
-
-  inputElement.addEventListener("focus", () => {
-    if (currentSuggestions.length > 0) {
-      dropdown.style.display = "block";
-    }
-  });
-
-  inputElement.addEventListener("keydown", (event) => {
-    if (event.key !== "Enter" || dropdown.style.display === "none") return;
-    const first = dropdown.querySelector(".suggestions-item");
-    if (first) {
-      event.preventDefault();
-      first.click();
-    }
-  });
-
-  document.addEventListener("click", (event) => {
-    if (!parent.contains(event.target)) {
-      dropdown.style.display = "none";
-    }
-  });
+if (window.google && window.google.maps && window.google.maps.places) {
+    initGoogleApis();
+} else {
+    window.addEventListener('google-maps-loaded', initGoogleApis);
 }
-
-setupAddressAutocomplete(originInput);
-setupAddressAutocomplete(destinationInput);
-
-setupAddressAutocomplete(originInput);
-setupAddressAutocomplete(destinationInput);
-
-setupAddressAutocomplete(originInput, "origin-suggestions");
-setupAddressAutocomplete(destinationInput, "destination-suggestions");
 
 const minLat = 39.00, maxLat = 39.9;
 const minLng = -0.75, maxLng = 0.1;
@@ -2666,7 +2563,7 @@ function isWithinBounds(latlng) {
 }
 
 // Cuando se hace click en el botón "Establecer dirección"
-document.getElementById("set-directions").addEventListener("click", async function() {
+document.getElementById("set-directions").addEventListener("click", function() {
 	
 	
 	console.log(window.innerWidth);
@@ -2696,43 +2593,51 @@ document.getElementById("set-directions").addEventListener("click", async functi
     return;
   }
 
-  const originData = await geocodeAddress(originAddress);
-  if (!originData) {
-    mostrarPopupInfo(tm("selecciona_origen"), "error");
-    return;
-  }
+  const geocoder = new google.maps.Geocoder();
 
-  pointA = L.latLng(originData.lat, originData.lng);
-  if (markerA) {
-    map.removeLayer(markerA);
-  }
+  geocoder.geocode({ address: originAddress }, function(results, status) {
+    if (status === google.maps.GeocoderStatus.OK && results[0]) {
+      const originLocation = results[0].geometry.location;
+      pointA = L.latLng(originLocation.lat(), originLocation.lng());
 
-  if (!isWithinBounds(pointA)) {
-    mostrarPopupInfo(tm("fuera_limites_origen"), "error");
-    return;
-  }
-  markerA = createMarker(pointA, "red");
+      if (markerA) {
+        map.removeLayer(markerA);
+      }
+      
+      if (!isWithinBounds(pointA)) {
+          mostrarPopupInfo(tm("fuera_limites_origen"), "error");
+          return;
+      }
+      
+      markerA = createMarker(pointA, "red");
 
-  const destinationData = await geocodeAddress(destinationAddress);
-  if (!destinationData) {
-    mostrarPopupInfo(tm("selecciona_destino"), "error");
-    return;
-  }
+      geocoder.geocode({ address: destinationAddress }, function(results2, status2) {
+        if (status2 === google.maps.GeocoderStatus.OK && results2[0]) {
+          const destinationLocation = results2[0].geometry.location;
+          pointB = L.latLng(destinationLocation.lat(), destinationLocation.lng());
 
-  pointB = L.latLng(destinationData.lat, destinationData.lng);
-  if (!isWithinBounds(pointB)) {
-    mostrarPopupInfo(tm("fuera_limites_destino"), "error");
-    return;
-  }
+          
+          if (!isWithinBounds(pointB)) {
+               mostrarPopupInfo(tm("fuera_limites_destino"), "error");
+              return;
+          }
+	        
+          if (markerB) {
+            map.removeLayer(markerB);
+          }
+          markerB = createMarker(pointB, "blue");
 
-  if (markerB) {
-    map.removeLayer(markerB);
-  }
-  markerB = createMarker(pointB, "blue");
-
-  document.getElementById("distance-info").innerText = "Origen y destino establecidos.";
-  moveToMidPointMarkers(pointA, pointB);
-  seleccionaOpcionTransporte();
+          document.getElementById("distance-info").innerText = "Origen y destino establecidos.";
+          moveToMidPointMarkers(pointA, pointB);
+          seleccionaOpcionTransporte();
+        } else {
+           mostrarPopupInfo(tm("selecciona_destino"), "error");
+        }
+      });
+    } else {
+      mostrarPopupInfo(tm("selecciona_origen"), "error");
+    }
+  });
 });
 
 

--- a/EcoMoveValencia/public/index.html
+++ b/EcoMoveValencia/public/index.html
@@ -898,6 +898,18 @@ body.dark-mode .leaflet-popup-tip {
   <!-- Incluir iconos de Lucide -->
   <script src="https://unpkg.com/lucide@latest"></script>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script>
+    // Carga dinámica de Google Maps con la clave obtenida del servidor
+    fetch('/api/google-maps-key')
+      .then(res => res.json())
+      .then(cfg => {
+        const script = document.createElement('script');
+        script.src = `https://maps.googleapis.com/maps/api/js?key=${cfg.apiKey}&libraries=geometry,places`;
+        script.async = true;
+        script.onload = () => window.dispatchEvent(new Event('google-maps-loaded'));
+        document.head.appendChild(script);
+      });
+  </script>
 <!-- SlickGrid CSS -->
 	   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/slickgrid@5.14.0/dist/styles/css/slick-alpine-theme.min.css">
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/slickgrid@5.14.0/dist/styles/css/slick.columnpicker.css"> 


### PR DESCRIPTION
### Motivation
- Reinstate the original typed origin/destination flow that uses Google Places Autocomplete and client-side Geocoder so users can type/select addresses with the Google modal behavior, even if that exposes the API key to the browser.

### Description
- Replaced the previous backend-driven typed-autocomplete UI with initialization of `google.maps.places.Autocomplete` for the origin and destination inputs and reintroduced `DirectionsService`/`DistanceMatrixService` setup in `public/JSProyecto.js`.
- Changed the route-setting logic on the search button to call `google.maps.Geocoder().geocode(...)` (client-side) and preserved existing bounds validation and marker creation before launching transport selection in `public/JSProyecto.js`.
- Added a dynamic client-side loader in `public/index.html` that fetches the key from `/api/google-maps-key` and injects the Google Maps+Places script, dispatching `google-maps-loaded` when ready.
- Added `/api/google-maps-key` in `api.js` to return the `GOOGLE_MAPS_API_KEY` environment value to the frontend, enabling the client-side Maps/Places load.

### Testing
- Ran `node --check EcoMoveValencia/public/JSProyecto.js` and the syntax check completed successfully.
- Ran `node --check EcoMoveValencia/api.js` and the syntax check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef37e6644883308b16f4ce914a5e7d)