### PR TITLE
Ajusta posición del toggle de tema y hace el logo de información clicable

### DIFF
--- a/EcoMoveValencia/public/index.html
+++ b/EcoMoveValencia/public/index.html
@@ -173,7 +173,7 @@
 .theme-toggle-btn {
     position: fixed;
     top: 3%;
-    right: 220px;
+    right: 12%;
     z-index: 1000;
     background-color: #ffffff;
     border: 1px solid #d1d5db;

--- a/EcoMoveValencia/public/information.html
+++ b/EcoMoveValencia/public/information.html
@@ -59,7 +59,7 @@
     .theme-toggle-btn {
       position: absolute;
       top: 3%;
-      right: 190px;
+      right: 12%;
       z-index: 1000;
       width: 38px;
       height: 38px;
@@ -72,10 +72,6 @@
     .theme-toggle-btn.is-dark {
       background-color: #111827;
       border-color: #4b5563;
-      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23f8fafc' d='M20.742 13.045A9 9 0 1 1 10.955 3.258a1 1 0 0 1 1.087 1.32A7 7 0 1 0 19.42 11.958a1 1 0 0 1 1.322 1.087z'/%3E%3C/svg%3E");
-      background-repeat: no-repeat;
-      background-position: center;
-      background-size: 18px 18px;
     }
     .theme-toggle-icon {
       width: 18px;
@@ -266,7 +262,7 @@ body.dark-mode .bar-track {
     <img id="themeToggleIconInfo" class="theme-toggle-icon" src="img/sol.svg" alt="">
   </button>
   <!-- Logo -->
-  <img src="img/logo1.png" alt="Logo" class="logo">
+  <a href="index.html"><img src="img/logo1.png" alt="Logo" class="logo"></a>
   <div class="container">
     <h1 id="titulo"></h1>
     <h2 id="contexto-titulo"></h2>


### PR DESCRIPTION
### Motivation
- Evitar que el botón de modo oscuro tenga una posición fija en píxeles para que se alinee correctamente en diferentes tamaños de ventana mediante un valor relativo.
- Eliminar el icono de luna duplicado en `information.html` cuando se activa el modo oscuro, dejando el icono gestionado por el `<img>` y no por `background-image` en CSS.
- Hacer que al pulsar el logo en `information.html` el usuario vuelva al mapa principal (`index.html`).

### Description
- Cambiado el posicionamiento horizontal del botón tema de `right: 220px` / `right: 190px` a `right: 12%` en `public/index.html` y `public/information.html` para usar un valor relativo. 
- Eliminado el `background-image` (SVG de luna) del selector `.theme-toggle-btn.is-dark` en `information.html` para evitar que se muestre junto al `<img>` del icono.
- Envuelto el logo en `information.html` con un enlace `<a href="index.html">` para que sea clicable y navegue de vuelta al mapa.
- Se aplicaron los cambios en los archivos `public/index.html` y `public/information.html` y se reescribió contenido HTML/CSS/JS afectado para mantener coherencia del layout.

### Testing
- Ejecutado `git -C /workspace/EcoMoveValencia/EcoMoveValencia diff --check` y no se detectaron errores de espacio en blanco (pasó).
- Ejecutado `git -C /workspace/EcoMoveValencia/EcoMoveValencia status --short` para verificar el estado del repositorio y confirmar los archivos modificados (`public/index.html`, `public/information.html`) y que `node_modules/` aparece como no versionado.
- Realizado `git -C /workspace/EcoMoveValencia/EcoMoveValencia commit` para crear el commit con los cambios aplicados (commit exitoso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7dbe4d908330ba065b8e49cbdd16)