### PR TITLE
Añadir sección de Contacto en information.html

### DIFF
--- a/EcoMoveValencia/public/information.html
+++ b/EcoMoveValencia/public/information.html
@@ -296,6 +296,8 @@ body.dark-mode .bar-track {
     <p>Enrique Hernández Orallo</p>
     <h2 id="tecnologias-titulo"></h2>
     <ul id="tecnologias-lista"></ul>
+    <h2 id="contacto-titulo"></h2>
+    <p><a href="mailto:martintoscanoupv@gmail.com">martintoscanoupv@gmail.com</a></p>
     <h2 id="legal-titulo"></h2>
     <p id="legal-texto"></p>
     <a href="index.html" class="back-btn" id="volver-boton"></a>
@@ -340,6 +342,7 @@ body.dark-mode .bar-track {
         "autor-titulo": "Autor",
         "tutor-titulo": "Tutor",
         "tecnologias-titulo": "Tecnologías utilizadas",
+        "contacto-titulo": "Contacto",
         "tecnologias-lista": [
           "Google Maps Directions API",
           "Open Data Valencia",
@@ -409,6 +412,7 @@ body.dark-mode .bar-track {
         "autor-titulo": "Autor",
         "tutor-titulo": "Tutor",
         "tecnologias-titulo": "Tecnologies utilitzades",
+        "contacto-titulo": "Contacte",
         "tecnologias-lista": [
           "Google Maps Directions API",
           "Open Data València",
@@ -477,6 +481,7 @@ body.dark-mode .bar-track {
         "autor-titulo": "Author",
         "tutor-titulo": "Supervisor",
         "tecnologias-titulo": "Technologies used",
+        "contacto-titulo": "Contact",
         "tecnologias-lista": [
           "Google Maps Directions API",
           "Open Data Valencia",
@@ -605,6 +610,7 @@ body.dark-mode .bar-track {
       document.getElementById("autor-titulo").innerText = t["autor-titulo"];
       document.getElementById("tutor-titulo").innerText = t["tutor-titulo"];
       document.getElementById("tecnologias-titulo").innerText = t["tecnologias-titulo"];
+      document.getElementById("contacto-titulo").innerText = t["contacto-titulo"];
       document.getElementById("legal-titulo").innerText = t["legal-titulo"];
       document.getElementById("legal-texto").innerText = t["legal-texto"];
       document.getElementById("volver-boton").innerText = t["volver-boton"];


### PR DESCRIPTION
### Motivation
- Añadir un apartado de contacto visible en la página de información para ofrecer un correo de contacto directo a los usuarios.

### Description
- Se añadió el bloque HTML con `h2` `id="contacto-titulo"` y un enlace `mailto:martintoscanoupv@gmail.com` en `public/information.html` justo después de la sección de tecnologías utilizadas.
- Se incorporó la clave de traducción `contacto-titulo` en los objetos de `traducciones` para `es`, `val` y `en` con los valores "Contacto", "Contacte" y "Contact" respectivamente.
- Se actualizó la función `cambiarIdioma` para asignar `t["contacto-titulo"]` al elemento `contacto-titulo` al inicializar o cambiar el idioma.

### Testing
- Se verificó que `public/information.html` contiene el nuevo `h2#contacto-titulo` y el enlace `mailto:` mostrado correctamente; la inspección del archivo local fue satisfactoria.
- El repositorio reflejó la modificación del archivo y la herramienta de creación de PR confirmó la creación del PR; no se ejecutaron pruebas unitarias automáticas adicionales.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f05f01013483308c4ea23378886736)