### PR TITLE
Use logo2 in dark mode for main and information pages

### DIFF
--- a/EcoMoveValencia/public/index.html
+++ b/EcoMoveValencia/public/index.html
@@ -790,7 +790,7 @@ body.dark-mode .leaflet-popup-tip {
 
   <header>
 <a href="information.html" style="z-index: 999; position: fixed; bottom: 2vh; left: 2vw;">
-  <img src="img/logo1.png" alt="Logo" class="logo" style="pointer-events: auto;">
+  <img id="mainLogo" src="img/logo1.png" alt="Logo" class="logo" style="pointer-events: auto;">
 </a>
 
 
@@ -1350,11 +1350,13 @@ applyMapTheme(savedTheme);
 
 const themeToggleBtn = document.getElementById("themeToggleBtn");
 const themeToggleIcon = document.getElementById("themeToggleIcon");
+const mainLogo = document.getElementById("mainLogo");
 
 function refreshThemeButton() {
     const darkEnabled = window.isDarkModeEnabled();
     themeToggleBtn.classList.toggle("is-dark", darkEnabled);
     themeToggleIcon.src = darkEnabled ? "img/luna.svg" : "img/sol.svg";
+    mainLogo.src = darkEnabled ? "img/logo2.png" : "img/logo1.png";
 }
 
 themeToggleBtn.addEventListener("click", () => {

--- a/EcoMoveValencia/public/information.html
+++ b/EcoMoveValencia/public/information.html
@@ -267,7 +267,7 @@ body.dark-mode .bar-track {
     <img id="themeToggleIconInfo" class="theme-toggle-icon" src="img/sol.svg" alt="">
   </button>
   <!-- Logo -->
-  <a href="index.html"><img src="img/logo1.png" alt="Logo" class="logo"></a>
+  <a href="index.html"><img id="infoLogo" src="img/logo1.png" alt="Logo" class="logo"></a>
   <div class="container">
     <h1 id="titulo"></h1>
     <h2 id="contexto-titulo"></h2>
@@ -635,11 +635,13 @@ body.dark-mode .bar-track {
     const emisionesValores = [102.14, 79.28, 65, 71.42, 43, 78.61, 53, 14, 49.9, 33, 30, 3, 0, 0];
     const themeToggleBtnInfo = document.getElementById("themeToggleBtnInfo");
     const themeToggleIconInfo = document.getElementById("themeToggleIconInfo");
+    const infoLogo = document.getElementById("infoLogo");
 
     function refreshInfoThemeButton() {
       const darkEnabled = document.body.classList.contains("dark-mode");
       themeToggleBtnInfo.classList.toggle("is-dark", darkEnabled);
       themeToggleIconInfo.src = darkEnabled ? "img/luna.svg" : "img/sol.svg";
+      infoLogo.src = darkEnabled ? "img/logo2.png" : "img/logo1.png";
     }
 
     const savedThemeInfo = localStorage.getItem("themeMode") === "dark";


### PR DESCRIPTION
### Motivation
- Ensure the site uses the dark-mode-appropriate branding by switching to `logo2.png` when the dark theme is active on both the main and information pages.

### Description
- Add `id="mainLogo"` and `id="infoLogo"` and update the theme refresh logic in `public/index.html` and `public/information.html` so the logo source is set to `img/logo2.png` for dark mode and `img/logo1.png` for light mode.

### Testing
- Applied the patches (`apply_patch` succeeded), verified the changes with `rg -n "mainLogo|infoLogo|logo2\.png"`, and committed the updates with `git commit` (all commands completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f06e00053c8330beb721037647091a)