### PR TITLE
Añade trazas de log para entrada web y solicitudes de rutas

### DIFF
--- a/EcoMoveValencia/api.js
+++ b/EcoMoveValencia/api.js
@@ -74,6 +74,36 @@ const router = express.Router();
 app.use(cors());
 app.use(express.json()); // Asegura que el body se maneje como JSON
 app.use(express.urlencoded({ extended: true }));
+
+function formatPointForLog(point) {
+    if (!point || !Number.isFinite(Number(point.lat)) || !Number.isFinite(Number(point.lng))) {
+        return 'desconocido';
+    }
+    return `${Number(point.lat).toFixed(6)},${Number(point.lng).toFixed(6)}`;
+}
+
+app.get('/', (req, res) => {
+    console.log(`[LOG] Usuario ha entrado en la web desde ${req.ip}.`);
+    res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
+app.post('/api/log-route-request', (req, res) => {
+    const { actionType, mode, origin, destination } = req.body || {};
+    const originText = formatPointForLog(origin);
+    const destinationText = formatPointForLog(destination);
+
+    if (actionType === 'COMPARE_ALL') {
+        console.log(`[LOG] Usuario ha pedido comparar todos entre ${originText} y ${destinationText}.`);
+    } else if (actionType === 'AI_PICK') {
+        console.log(`[LOG] Usuario ha pedido a la IA escoger ruta entre ${originText} y ${destinationText}.`);
+    } else {
+        const modeText = mode || 'desconocido';
+        console.log(`[LOG] Usuario ha pedido ruta en ${modeText} entre ${originText} y ${destinationText}.`);
+    }
+
+    return res.json({ ok: true });
+});
+
 app.use(express.static(path.join(__dirname, 'public')));
 
 // Endpoint para proporcionar la clave de Google Maps al cliente

--- a/EcoMoveValencia/public/JSProyecto.js
+++ b/EcoMoveValencia/public/JSProyecto.js
@@ -7,6 +7,25 @@ let inicio;
         function calculateDistanceAndRoute() {
           if (!pointA || !pointB) return;
 
+          const actionType = transportMode === "COMPARA"
+            ? "COMPARE_ALL"
+            : transportMode === "AI_PICK"
+              ? "AI_PICK"
+              : "ROUTE";
+
+          fetch("/api/log-route-request", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              actionType,
+              mode: transportMode,
+              origin: pointA,
+              destination: pointB
+            })
+          }).catch(error => {
+            console.warn("No se pudo registrar la solicitud de ruta:", error);
+          });
+
 		  if (transportMode === "COMPARA") {
 			inicio = performance.now();
 		      let modes = ["WALKING", "DRIVING", "BICYCLING", "PATINETE", "Valenbisi", "METRO", "BUS", "TRAIN", "ELECTRIC_MOTORBIKE", "TAXI"];


### PR DESCRIPTION
### Motivation
- Registrar en el servidor cuándo un usuario entra en la web para tener una línea clara de acceso.
- Registrar las solicitudes de rutas con una sola línea por evento para evitar spam en el log cuando se comparan todos los modos.
- También registrar cuándo el usuario pide a la IA que escoja una ruta para auditar esa acción.

### Description
- Se añade `formatPointForLog` y `GET /` en `api.js` para escribir en el log una línea al entrar en la web con la IP del cliente. 
- Se añade el endpoint `POST /api/log-route-request` en `api.js` que recibe `{ actionType, mode, origin, destination }` y escribe en log una línea según `actionType` (`COMPARE_ALL`, `AI_PICK`, `ROUTE`) incluyendo origen/destino en formato `lat,lng` (6 decimales) cuando están disponibles.
- En `public/JSProyecto.js` se inyecta una llamada `fetch('/api/log-route-request', ...)` al inicio de `calculateDistanceAndRoute()` que envía un único evento por petición de ruta; el `actionType` se determina como `COMPARE_ALL`, `AI_PICK` o `ROUTE` según `transportMode`.
- La solución evita registrar múltiples líneas durante la comparación de todos los modos (se envía una sola petición con `COMPARE_ALL`) y añade manejo de errores silencioso en el `fetch` del frontend.

### Testing
- Comprobación de sintaxis de Node para el servidor con `node --check api.js` y para el frontend con `node --check public/JSProyecto.js`, ambos pasaron sin errores.
- Se validó localmente que las funciones `calculateDistanceAndRoute` y el nuevo endpoint aceptan el payload esperado (petición `POST /api/log-route-request` responde `{ ok: true }`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b383be308330ad0dcf3ff6c5e746)