### PR TITLE
Agregar variable de entorno `GOOGLE_MAPS_FRONT_API_KEY` para el front

### DIFF
--- a/EcoMoveValencia/api.js
+++ b/EcoMoveValencia/api.js
@@ -70,6 +70,7 @@ let stationBusUsage = [];
 let stationRodaliaUsage = [];
 // Clave de Google Maps obtenida de la variable de entorno
 const apiKey = process.env.GOOGLE_MAPS_API_KEY || "";
+const frontMapsApiKey = process.env.GOOGLE_MAPS_FRONT_API_KEY || apiKey;
 const router = express.Router();
 app.use(cors());
 app.use(express.json()); // Asegura que el body se maneje como JSON
@@ -109,7 +110,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 // Endpoint para proporcionar la clave de Google Maps al cliente
 app.get('/api/google-maps-key', (req, res) => {
     res.setHeader('Content-Type', 'application/json');
-    res.json({ apiKey });
+    res.json({ apiKey: frontMapsApiKey });
 });
 
 async function nominatimSearch(params) {


### PR DESCRIPTION
### Motivation
- Permitir usar una clave distinta en el navegador para funcionalidades de Google Maps/Places (p. ej. selector por escritura / autocomplete) sin cambiar la clave usada por las llamadas del servidor.

### Description
- Se añadió `frontMapsApiKey = process.env.GOOGLE_MAPS_FRONT_API_KEY || apiKey` en `api.js` y el endpoint `GET /api/google-maps-key` ahora devuelve `frontMapsApiKey` en lugar de la clave del servidor (`apiKey`).

### Testing
- Ejecuté `node --check api.js` y la comprobación de sintaxis pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f210460390833082f3e1ed3e399a49)